### PR TITLE
rename lipstick to glacier

### DIFF
--- a/glacier-home.pro
+++ b/glacier-home.pro
@@ -1,7 +1,7 @@
 # Main project file for Glacier home
 
 TEMPLATE = app
-TARGET = lipstick
+TARGET = glacier-home
 VERSION = 0.1
 
 INSTALLS = target
@@ -99,10 +99,10 @@ settingspluginconfig.files = src/settings-plugins/wallpaper/wallpaper.json \
 
 settingspluginconfig.path = /usr/share/glacier-settings/plugins
 
-systemd.files = rpm/lipstick.service
+systemd.files = rpm/glacier.service
 systemd.path = /usr/lib/systemd/user
 
-desktop.files = rpm/lipstick.desktop
+desktop.files = rpm/glacier.desktop
 desktop.path = /etc/xdg/autostart
 
 INSTALLS += styles \

--- a/rpm/glacier.desktop
+++ b/rpm/glacier.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Exec=/usr/bin/lipstick
+Exec=/usr/bin/glacier-home
 X-Moblin-Priority=High
 OnlyShowIn=X-MEEGO-HS;
 X-Meego-Watchdog=Restart

--- a/rpm/glacier.service
+++ b/rpm/glacier.service
@@ -1,12 +1,12 @@
 [Unit]
-Description=The lipstick UI
+Description=The Glacier UI
 Requires=dbus.socket pre-user-session.target
 After=pre-user-session.target
 
 [Service]
 EnvironmentFile=-/var/lib/environment/compositor/*.conf
 EnvironmentFile=-/usr/share/lipstick-glacier-home-qt5/nemovars.conf
-ExecStart=/usr/bin/invoker --type=generic /usr/bin/lipstick $LIPSTICK_OPTIONS --systemd
+ExecStart=/usr/bin/invoker --type=generic /usr/bin/glacier-home $LIPSTICK_OPTIONS --systemd
 Restart=always
 
 [Install]

--- a/rpm/lipstick-glacier-home-qt5.spec
+++ b/rpm/lipstick-glacier-home-qt5.spec
@@ -6,7 +6,7 @@ Group:      System/GUI/Other
 License:    BSD
 URL:        https://github.com/locusf/glacier-home
 Source0:    %{name}-%{version}.tar.bz2
-Source1:    lipstick.service
+Source1:    glacier.service
 
 Requires:   lipstick-qt5 >= 0.17.0
 Requires:   nemo-qml-plugin-configuration-qt5
@@ -55,17 +55,17 @@ mkdir -p %{buildroot}%{_libdir}/systemd/user
 cp %{SOURCE1} %{buildroot}%{_libdir}/systemd/user
 
 mkdir -p %{buildroot}%{_libdir}/systemd/user/user-session.target.wants/
-ln -s ../lipstick.service %{buildroot}%{_libdir}/systemd/user/user-session.target.wants/lipstick.service
+ln -s ../glacier.service %{buildroot}%{_libdir}/systemd/user/user-session.target.wants/glacier.service
 
 %files
 %defattr(-,root,root,-)
-%{_bindir}/lipstick
-%{_libdir}/systemd/user/lipstick.service
-%{_libdir}/systemd/user/user-session.target.wants/lipstick.service
+%{_bindir}/glacier-home
+%{_libdir}/systemd/user/glacier.service
+%{_libdir}/systemd/user/user-session.target.wants/glacier.service
 %{_datadir}/lipstick-glacier-home-qt5/nemovars.conf
 %{_datadir}/lipstick-glacier-home-qt5/qml
 %{_datadir}/lipstick-glacier-home-qt5/translations
 %{_datadir}/glacier-settings/
 
 %post
-systemctl-user --no-block restart lipstick.service
+systemctl-user --no-block restart glacier.service


### PR DESCRIPTION
this PR solve a problem with need to reinstall home screen packages each time when you need to switch from one to another.
right now there are two such packages with duplicated binaries: lipstick-glacier-home-qt5 and lipstick-jolla-home-qt5

```
# rpm -ql lipstick-glacier-home-qt5-0.27.8-56.1.Nemo.UX.MTF.i486.rpm   
/etc/xdg/autostart/lipstick.desktop
/usr/bin/lipstick
/usr/lib/systemd/user/lipstick.service
/usr/lib/systemd/user/user-session.target.wants/lipstick.service
...

# rpm -ql lipstick-jolla-home-qt5-0.37.2.1-1.10.2.jolla.i486.rpm
/etc/mce/60-devicelock-lipstick-jolla-home.conf
/etc/mce/60-powerkey-lipstick-jolla-home.conf
/etc/polkit-1/localauthority.conf.d/90-sailfish-authentication.conf
/usr/bin/lipstick
/usr/bin/lipstick-bluetooth-ui
/usr/bin/lipstick-obex-ui
/usr/bin/lipstick-windowprompt
/usr/lib/oneshot.d/enable-lipstick-hints
/usr/lib/systemd/user/lipstick-security-ui.service
/usr/lib/systemd/user/lipstick.service
/usr/lib/systemd/user/user-session.target.wants/lipstick-security-ui.service
/usr/lib/systemd/user/user-session.target.wants/lipstick.service
...
```