### PR TITLE
[packaging] remove lipstick.desktop

### DIFF
--- a/glacier-home.pro
+++ b/glacier-home.pro
@@ -102,9 +102,6 @@ settingspluginconfig.path = /usr/share/glacier-settings/plugins
 systemd.files = rpm/lipstick.service
 systemd.path = /usr/lib/systemd/user
 
-desktop.files = rpm/lipstick.desktop
-desktop.path = /etc/xdg/autostart
-
 INSTALLS += styles \
             images \
             theme \

--- a/rpm/lipstick.desktop
+++ b/rpm/lipstick.desktop
@@ -1,5 +1,0 @@
-[Desktop Entry]
-Exec=/usr/bin/lipstick
-X-Moblin-Priority=High
-OnlyShowIn=X-MEEGO-HS;
-X-Meego-Watchdog=Restart


### PR DESCRIPTION
this fixes packaging problem, when packager complains that file is installed but not packaged.

looks like now there is no need to autostart by using xdg, we already use systemd service.