### PR TITLE
folder wasn't removed when 1 item left due to name collision 

### DIFF
--- a/src/qml/applauncher/LauncherItemWrapper.qml
+++ b/src/qml/applauncher/LauncherItemWrapper.qml
@@ -246,7 +246,7 @@ MouseArea {
     Connections {
         target: modelData.object
         ignoreUnknownSignals: true
-        function onItemRemoved(modelData) {
+        function onItemRemoved(removedModelData) {
             var modelDataObject = modelData.object
             //If there is only one item in folder, remove the folder
             if (modelDataObject.itemCount === 1) {


### PR DESCRIPTION
There were two modelData. First belongs to the folder and and second belongs the removed item.

Here is the animation of incorrect behavior.

![folder_to_single_app_bug](https://user-images.githubusercontent.com/6171637/120674637-94779180-c494-11eb-9fdd-eefeab27494a.gif)

Expected behavior is to close folder and transform folder to LauncherItemDelegate. See:

![fixed](https://user-images.githubusercontent.com/6171637/120675497-6ba3cc00-c495-11eb-95a1-b8e6cacd4c85.gif)
