### PR TITLE
Make control center open fully after gesture has finished

### DIFF
--- a/src/qml/GlacierCompositor.qml
+++ b/src/qml/GlacierCompositor.qml
@@ -211,6 +211,16 @@ Item {
                     cancelAnimation.start()
                 }
             }
+
+            if (!Desktop.instance.lockscreenVisible() && !diagonal) {
+                if (gesture == "down") {
+                    if (gestureArea.value >= Desktop.instance.height / 2) {
+                        Desktop.instance.controlcenter.height = Desktop.instance.height
+                    } else {
+                        Desktop.instance.controlcenter.height = Theme.itemHeightHuge+Theme.itemSpacingSmall*2
+                    }
+                }
+            }
             comp.gestureOnGoing = false
         }
         // States are for the animations that follow your finger during swipes


### PR DESCRIPTION
Currently, the control center leaves itself hanging when the swipe gesture is over. This commit makes it open fully after the gesture has finished.