### PR TITLE
ReferenceError: Desktop is not defined

### DIFF
--- a/src/qml/MainScreen.qml
+++ b/src/qml/MainScreen.qml
@@ -274,7 +274,7 @@ Item {
         Pager {
             id: pager
             anchors.fill: parent
-            enabled: Desktop.compositor.state != "controlCenter"
+            enabled: Lipstick.compositor.state != "controlCenter"
             model: visualItemsModel
             // Initial view should be the AppLauncher
             currentIndex: 1


### PR DESCRIPTION
I can see following error in logs:
file:///usr/share/lipstick-glacier-home-qt5/qml/MainScreen.qml:277: ReferenceError: Desktop is not defined

It should be either Lipstick.compositor or lowercase desktop, but not sure if desktop.compositor exists.