### PR TITLE
don't break the binding of volumeControl.windowVisible

### DIFF
--- a/src/qml/volumecontrol/VolumeControl.qml
+++ b/src/qml/volumecontrol/VolumeControl.qml
@@ -107,7 +107,7 @@ Rectangle{
     Timer {
         id: voltimer
         interval: 2000
-        onTriggered: volumeControlWindow.visible = false
+        onTriggered: volumeControl.windowVisible = false
     }
 
     Connections {


### PR DESCRIPTION
(1) The button sets volumeControl.windowVisible to true, which is binded to volumeControlWindow.visible
(2) The timeout trigger sets volumeControlWindow.visible to false
(3) The button sets volumeControl.windowVisible to true, but volumeControlWindow.visible remains false
